### PR TITLE
Fix for &gt and &lt

### DIFF
--- a/src/org/fit/vips/VipsOutput.java
+++ b/src/org/fit/vips/VipsOutput.java
@@ -214,8 +214,8 @@ public final class VipsOutput {
 				transformer.transform(source, new StreamResult(writer));
 				String result = writer.toString();
 
-				result = result.replaceAll("&gt;", "<");
-				result = result.replaceAll("&lt;", ">");
+				result = result.replaceAll("&gt;", ">");
+				result = result.replaceAll("&lt;", "<");
 				result = result.replaceAll("&quot;", "\"");
 
 				FileWriter fstream = new FileWriter(_filename + ".xml");


### PR DESCRIPTION
Hi, I noticed a small bug in your otherwise excellent library:

&gt and &lt are replaced by "<" and ">", which is the wrong way round of course.
So I changed just that.
